### PR TITLE
Update crowdin.yml for Crowdin sync

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,21 +1,3 @@
 files:
-  - source: /book/website/
-    ignore:
-      - LICENSE.md
-      - _toc.yml
-      - _config.yml
-      - _redirects
-      - /requirements.txt
-      - runtime.txt
-      - figures
-      - '*.png'
-      - '*.jpg'
-      - _build/html
-      - _static
-      - scripts
-      - requirements
-      - translation
-      - figures
-      - assets
-      - analytic
+  - source: /book/website/**/*.md
     translation: /book/translation/%three_letters_code%/%original_path%/%original_file_name%


### PR DESCRIPTION
Only Markdown files are expected to be sent for translation, therefore configuration file is updated

### Summary

There are many non-translatable items in Crowdin project right now:
https://turingway.crowdin.com/turing-way/fr

The improvement for Crowdin <-> GitHub sync addresses the issue, so only Markdown files with texts would be synced.

### List of changes proposed in this PR (pull-request)

* *Crowdin configuration file improvements*

### What should a reviewer concentrate their feedback on?

- [ ] After merging changes, please pause/resume the sync in Crowdin to apply changes;
- [ ] Crowdin team representative will help you with files re-upload

### Acknowledging contributors

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/main/README.md#contributors) in the README file: @Andrulko
